### PR TITLE
Enabling tree-view keyboard shortcuts for previewing files

### DIFF
--- a/keymaps/sublime-tabs.cson
+++ b/keymaps/sublime-tabs.cson
@@ -57,9 +57,9 @@
   'ctrl-9': 'tree-view:open-selected-entry-in-pane-9'
 
 '.tree-view':
-  'right': 'tree-view:expand-directory'
-  'ctrl-]': 'tree-view:expand-directory'
-  'l': 'tree-view:expand-directory'
+  'right': 'tree-view:expand-directory-or-preview-file'
+  'ctrl-]': 'tree-view:expand-directory-or-preview-file'
+  'l': 'tree-view:expand-directory-or-preview-file'
   'left': 'tree-view:collapse-directory'
   'ctrl-[': 'tree-view:collapse-directory'
   'alt-ctrl-]': 'tree-view:recursive-expand-directory'

--- a/lib/sublime-tree-view.coffee
+++ b/lib/sublime-tree-view.coffee
@@ -1,11 +1,16 @@
 {$} = require 'atom'
 
 TreeView      = require atom.packages.resolvePackagePath('tree-view') + '/lib/tree-view'
+DirectoryView = require atom.packages.resolvePackagePath('tree-view') + '/lib/directory-view'
+FileView      = require atom.packages.resolvePackagePath('tree-view') + '/lib/file-view'
 
 module.exports =
 class SublimeTreeView extends TreeView
   initialize: (state) ->
     super(state)
+
+    atom.commands.add '.tree-view',
+      'tree-view:expand-directory-or-preview-file', => @expandDirOrPreview()
 
     @on 'dblclick', '.entry', (e) ->
       return if e.shiftKey || e.metaKey || e.altKey
@@ -15,3 +20,10 @@ class SublimeTreeView extends TreeView
   entryDblClicked: (e) ->
     @selectedEntry = $(e.currentTarget).view()
     @openSelectedEntry(false, true)
+
+  expandDirOrPreview: () ->
+    selectedEntry = @selectedEntry()
+    if selectedEntry instanceof DirectoryView
+      selectedEntry.expand(false)
+    else if selectedEntry instanceof FileView
+      atom.workspace.open(selectedEntry.getPath(), activatePane:false)


### PR DESCRIPTION
I want to be able to quickly preview files in the tree view using the keyboard but found that the only keyboard shortcut ('enter') would lose the focus of the tree view.  This PR allows files to be previewed using the :arrow_right:  key when on a file in the tree view (previously a right arrow on a tree view file did nothing).  