### PR TITLE
Settings tab doesn't replace temporary tab

### DIFF
--- a/lib/sublime-tab-bar-view.coffee
+++ b/lib/sublime-tab-bar-view.coffee
@@ -31,8 +31,9 @@ class SublimeTabBarView extends TabBarView
       false
 
   addTabForItem: (item, index) ->
-    for tab in @getTabs()
-      @closeTab(tab) if tab.is('.temp')
+    if item.activePanelName != "Settings"
+        for tab in @getTabs()
+          @closeTab(tab) if tab.is('.temp')
 
     tabView = new SublimeTabView(item, @pane, @openPermanent, @considerTemp)
     @insertTabAtIndex(tabView, index)


### PR DESCRIPTION
In my optinion, the Atom Settings page should not replace the current temporary tab