### PR TITLE
Fixing missing resize cursor for tree-view on Windows

### DIFF
--- a/stylesheets/sublime-tree-view.less
+++ b/stylesheets/sublime-tree-view.less
@@ -51,3 +51,13 @@
     position: absolute;
   }
 }
+
+.platform-win32 {
+
+  .tree-view-resizer {
+
+    .tree-view-resize-handle {
+      cursor: ew-resize;
+    }
+  }
+}


### PR DESCRIPTION
https://github.com/atom/tree-view/pull/148 causes the resize cursor to be missing on Windows. The issue was patched in `tree-view` but not in `sublime-tabs`.
This pull request copies the solution from tree-view (from [this](https://github.com/atom/tree-view/commit/d68d32c2745c4b9faebf0897d96cc9242eb9187f) commit).
