### PR TITLE
Adjust index to insert at, if a lower-index tab is removed first

### DIFF
--- a/lib/sublime-tab-bar-view.coffee
+++ b/lib/sublime-tab-bar-view.coffee
@@ -30,11 +30,13 @@ class SublimeTabBarView extends TabBarView
       tab.removeClass('temp') if tab.is('.temp')
       false
 
-  addTabForItem: (item, index) ->
+  addTabForItem: (item, insertIndex) ->
     if item.uri != "atom://config"
-        for tab in @getTabs()
-          @closeTab(tab) if tab.is('.temp')
+        for tab, tempIndex in @getTabs()
+          if tab.is('.temp')
+            @closeTab(tab)
+            insertIndex -= 1 if tempIndex < insertIndex
 
     tabView = new SublimeTabView(item, @pane, @openPermanent, @considerTemp)
-    @insertTabAtIndex(tabView, index)
+    @insertTabAtIndex(tabView, insertIndex)
     @updateActiveTab()


### PR DESCRIPTION
This resolves #110 by subtracting one from the index to insert at, when a previous tab is removed by doing the insert.